### PR TITLE
Extracting music links from fb chat messages

### DIFF
--- a/BajaMusic/Manifest.toml
+++ b/BajaMusic/Manifest.toml
@@ -1,0 +1,27 @@
+# This file is machine-generated - editing it directly is not advised
+
+[[Dates]]
+deps = ["Printf"]
+uuid = "ade2ca70-3891-5945-98fb-dc099432e06a"
+
+[[JSON]]
+deps = ["Dates", "Mmap", "Parsers", "Unicode"]
+git-tree-sha1 = "81690084b6198a2e1da36fcfda16eeca9f9f24e4"
+uuid = "682c06a0-de6a-54ab-a142-c8b1cf79cde6"
+version = "0.21.1"
+
+[[Mmap]]
+uuid = "a63ad114-7e13-5084-954f-fe012c677804"
+
+[[Parsers]]
+deps = ["Dates"]
+git-tree-sha1 = "50c9a9ed8c714945e01cd53a21007ed3865ed714"
+uuid = "69de0a69-1ddd-5017-9359-2bf0b02dc9f0"
+version = "1.0.15"
+
+[[Printf]]
+deps = ["Unicode"]
+uuid = "de0858da-6303-5e67-8744-51eddeeeb8d7"
+
+[[Unicode]]
+uuid = "4ec0a83e-493e-50e2-b9ac-8f72acf5a8f5"

--- a/BajaMusic/Manifest.toml
+++ b/BajaMusic/Manifest.toml
@@ -1,8 +1,28 @@
 # This file is machine-generated - editing it directly is not advised
 
+[[Base64]]
+uuid = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"
+
+[[CodeTracking]]
+deps = ["InteractiveUtils", "UUIDs"]
+git-tree-sha1 = "8ad457cfeb0bca98732c97958ef81000a543e73e"
+uuid = "da1fd8a2-8d9e-5ec2-8556-3022fb5608a2"
+version = "1.0.5"
+
 [[Dates]]
 deps = ["Printf"]
 uuid = "ade2ca70-3891-5945-98fb-dc099432e06a"
+
+[[Distributed]]
+deps = ["Random", "Serialization", "Sockets"]
+uuid = "8ba89e20-285c-5b6f-9357-94700520ee1b"
+
+[[FileWatching]]
+uuid = "7b1f6079-737a-58dc-b8bc-7a2ca5c1b5ee"
+
+[[InteractiveUtils]]
+deps = ["Markdown"]
+uuid = "b77e0a4c-d291-57a0-90e8-8db25a27a240"
 
 [[JSON]]
 deps = ["Dates", "Mmap", "Parsers", "Unicode"]
@@ -10,8 +30,39 @@ git-tree-sha1 = "81690084b6198a2e1da36fcfda16eeca9f9f24e4"
 uuid = "682c06a0-de6a-54ab-a142-c8b1cf79cde6"
 version = "0.21.1"
 
+[[JuliaInterpreter]]
+deps = ["CodeTracking", "InteractiveUtils", "Random", "UUIDs"]
+git-tree-sha1 = "fe18234f046a772069abdc8d29f073d8c0f092a5"
+uuid = "aa1ae85d-cabe-5617-a682-6adf51b2e16a"
+version = "0.8.8"
+
+[[LibGit2]]
+deps = ["Printf"]
+uuid = "76f85450-5226-5b5a-8eaa-529ad045b433"
+
+[[Libdl]]
+uuid = "8f399da3-3557-5675-b5ff-fb832c97cbdb"
+
+[[Logging]]
+uuid = "56ddb016-857b-54e1-b83d-db4d58db5568"
+
+[[LoweredCodeUtils]]
+deps = ["JuliaInterpreter"]
+git-tree-sha1 = "f008f15264cc11de6de8cbdda3d4712dd152f0c3"
+uuid = "6f1432cf-f94c-5a45-995e-cdbf5db27b0b"
+version = "1.2.7"
+
+[[Markdown]]
+deps = ["Base64"]
+uuid = "d6f4376e-aef5-505a-96c1-9c027394607a"
+
 [[Mmap]]
 uuid = "a63ad114-7e13-5084-954f-fe012c677804"
+
+[[OrderedCollections]]
+git-tree-sha1 = "cf59cfed2e2c12e8a2ff0a4f1e9b2cd8650da6db"
+uuid = "bac558e1-5e72-5ebc-8fee-abe8a469f55d"
+version = "1.3.2"
 
 [[Parsers]]
 deps = ["Dates"]
@@ -19,9 +70,46 @@ git-tree-sha1 = "50c9a9ed8c714945e01cd53a21007ed3865ed714"
 uuid = "69de0a69-1ddd-5017-9359-2bf0b02dc9f0"
 version = "1.0.15"
 
+[[Pkg]]
+deps = ["Dates", "LibGit2", "Libdl", "Logging", "Markdown", "Printf", "REPL", "Random", "SHA", "UUIDs"]
+uuid = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
+
 [[Printf]]
 deps = ["Unicode"]
 uuid = "de0858da-6303-5e67-8744-51eddeeeb8d7"
+
+[[REPL]]
+deps = ["InteractiveUtils", "Markdown", "Sockets"]
+uuid = "3fa0cd96-eef1-5676-8a61-b3b8758bbffb"
+
+[[Random]]
+deps = ["Serialization"]
+uuid = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
+
+[[Requires]]
+deps = ["UUIDs"]
+git-tree-sha1 = "cfbac6c1ed70c002ec6361e7fd334f02820d6419"
+uuid = "ae029012-a4dd-5104-9daa-d747884805df"
+version = "1.1.2"
+
+[[Revise]]
+deps = ["CodeTracking", "Distributed", "FileWatching", "JuliaInterpreter", "LibGit2", "LoweredCodeUtils", "OrderedCollections", "Pkg", "REPL", "Requires", "UUIDs", "Unicode"]
+git-tree-sha1 = "176c817f5e5a9c78fd0d91483dadc88cc5805c41"
+uuid = "295af30f-e4ad-537b-8983-00126c2a3abe"
+version = "3.1.11"
+
+[[SHA]]
+uuid = "ea8e919c-243c-51af-8825-aaa63cd721ce"
+
+[[Serialization]]
+uuid = "9e88b42a-f829-5b0c-bbe9-9e923198166b"
+
+[[Sockets]]
+uuid = "6462fe0b-24de-5631-8697-dd941f90decc"
+
+[[UUIDs]]
+deps = ["Random", "SHA"]
+uuid = "cf7118a7-6976-5b1a-9a39-7adc72f591a4"
 
 [[Unicode]]
 uuid = "4ec0a83e-493e-50e2-b9ac-8f72acf5a8f5"

--- a/BajaMusic/Project.toml
+++ b/BajaMusic/Project.toml
@@ -1,0 +1,2 @@
+[deps]
+JSON = "682c06a0-de6a-54ab-a142-c8b1cf79cde6"

--- a/BajaMusic/Project.toml
+++ b/BajaMusic/Project.toml
@@ -1,2 +1,4 @@
 [deps]
 JSON = "682c06a0-de6a-54ab-a142-c8b1cf79cde6"
+Logging = "56ddb016-857b-54e1-b83d-db4d58db5568"
+Revise = "295af30f-e4ad-537b-8983-00126c2a3abe"

--- a/BajaMusic/process.jl
+++ b/BajaMusic/process.jl
@@ -1,0 +1,12 @@
+using JSON
+
+f = read("message_1.json", String)
+fd = JSON.parse(f)
+msgs = fd["messages"]
+
+
+for msg in msgs
+	if msgs contains "spotify" or "apple" or youtube
+		 
+	end
+	

--- a/BajaMusic/process.jl
+++ b/BajaMusic/process.jl
@@ -1,12 +1,46 @@
 using JSON
+using Logging
 
-f = read("message_1.json", String)
-fd = JSON.parse(f)
-msgs = fd["messages"]
+# msgs = readjson("message_1.json")
+function readjson(fname)
+	f = read(fname, String)
+	fd = JSON.parse(f)
+	return fd["messages"]
+end
 
-
-for msg in msgs
-	if msgs contains "spotify" or "apple" or youtube
-		 
+function collectlinks(messages)
+	links = String[]
+	for i in 1:size(messages, 1)
+		msg = messages[i]
+		haskey(msg, "content") || continue
+		msgc = msg["content"]
+		if occursin("spotify.", msgc) || occursin("music.apple", msgc) || occursin("youtube.", msgc)
+			if occursin("\n", msgc)
+				#@show i
+				msgcs = split(msgc, "\n")
+				for msgc in msgcs
+					occursin(".com", msgc) && push!(links, msgc)
+				end
+			else
+				push!(links, msgc)
+			end
+		end
 	end
-	
+	return links
+end
+
+function writehtml(links, endfile)
+	open(endfile, "w") do io
+		println(io, "<!DOCTYPE html>\n<html>\n<body>")
+		for l in links
+			println(io, """<p><a href="$l">$l</a></p>""")
+		end
+		println(io, "</body>\n</html>")
+	end
+	@info "Finished writing $(length(links)) links."
+end
+
+# completeproc("message_1.json")
+function completeproc(fname)
+	readjson(fname) |> collectlinks |> x -> writehtml(x, "links.html")
+end


### PR DESCRIPTION
The script enables one to extract spotify, youtube and apple music links from facebook chats.
One needs to download their facebook data (in json format), then search for the wanted `message_.json` file and use the function provided by this PR.